### PR TITLE
Fix example program, allow serializing Order direction

### DIFF
--- a/GremlinSample/Program.cs
+++ b/GremlinSample/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Gremlin.Net.CosmosDb;
+using Gremlin.Net.Process.Traversal;
 using GremlinSample.Schema;
 using Newtonsoft.Json;
 using System;
@@ -8,13 +9,22 @@ namespace GremlinSample
 {
     internal class Program
     {
-        private static async Task Main(string[] args)
+        private static void Main(string[] args)
+        {
+            Run().Wait();
+
+            Console.WriteLine();
+            Console.WriteLine("All done...");
+            Console.ReadKey();
+        }
+
+        private static async Task Run()
         {
             using (var graphClient = new GraphClient("graph-test-bplehal.gremlin.cosmosdb.azure.com", "evo", "CMS", "6agjPRz3wZlwdErfasKon2kbNug0z75fVdfL53uuaG7OTZxOxqoyvId3irOCDJgfkgxUwlZ3qV5aNLLBSGWy1w=="))
             {
                 var g = graphClient.CreateTraversalSource();
 
-                var query = g.V<PersonVertex>("1").Out(v => v.Purchased);
+                var query = g.V<PersonVertex>("1").Out(v => v.Purchased).Order().By("id", Order.Decr);
                 Console.WriteLine(query.ToGremlinQuery());
                 var response = await graphClient.SubmitAsync(query);
 
@@ -26,10 +36,6 @@ namespace GremlinSample
                     Console.WriteLine(json);
                 }
             }
-
-            Console.WriteLine();
-            Console.WriteLine("All done...");
-            Console.ReadKey();
         }
     }
 }

--- a/src/Gremlin.Net.CosmosDb/Serialization/GremlinQuerySerializer.cs
+++ b/src/Gremlin.Net.CosmosDb/Serialization/GremlinQuerySerializer.cs
@@ -113,6 +113,15 @@ namespace Gremlin.Net.CosmosDb.Serialization
         }
 
         /// <summary>
+        /// Serializes the specified order.
+        /// </summary>
+        /// <param name="order">The order.</param>
+        private void Serialize(Order order)
+        {
+            _writer.Write(order.ToString().ToLowerInvariant());
+        }
+
+        /// <summary>
         /// Serializes the specified enum.
         /// </summary>
         /// <param name="enum">The enum.</param>


### PR DESCRIPTION
Example program would not compile with async main.  I moved the executing code to a separate function.

Also, query of `Order().By("Property", Order.Decr)` would serialize incorrectly, so I added a serializer for the `Order` enum