### PR TITLE
Added serializer support for Pop and Column enums used in Select steps

### DIFF
--- a/src/Gremlin.Net.CosmosDb/Serialization/GremlinQuerySerializer.cs
+++ b/src/Gremlin.Net.CosmosDb/Serialization/GremlinQuerySerializer.cs
@@ -110,6 +110,24 @@ namespace Gremlin.Net.CosmosDb.Serialization
         }
 
         /// <summary>
+        /// Serializes the specified Column enum.
+        /// </summary>
+        /// <param name="column">The column.</param>
+        private void Serialize(Column column)
+        {
+            _writer.Write(column.EnumValue);
+        }
+
+        /// <summary>
+        /// Serializes the specified Pop enum.
+        /// </summary>
+        /// <param name="pop">The pop.</param>
+        private void Serialize(Pop pop)
+        {
+            _writer.Write(pop.EnumValue);
+        }
+
+        /// <summary>
         /// Serializes the specified unique identifier.
         /// </summary>
         /// <param name="guid">The unique identifier.</param>


### PR DESCRIPTION
I had a query that uses the `Column.Values` enum for a Select step.  Thought I would share.