### PR TITLE
Downgrade Gremlin.Net to 3.4.0-rc2

### DIFF
--- a/src/Gremlin.Net.CosmosDb/Gremlin.Net.CosmosDb.csproj
+++ b/src/Gremlin.Net.CosmosDb/Gremlin.Net.CosmosDb.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Gremlin.Net" Version="3.4.0" />
+    <PackageReference Include="Gremlin.Net" Version="3.4.0-rc2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This is a temporary fix to issue #49.
The proper fix is of course fixing the return value.