### PR TITLE
Consult JsonProperty.PropertyName on model properties when using SchemaBound Property()

### DIFF
--- a/src/Gremlin.Net.CosmosDb/ISchemaBoundTraversal.Schema.Extensions.cs
+++ b/src/Gremlin.Net.CosmosDb/ISchemaBoundTraversal.Schema.Extensions.cs
@@ -432,6 +432,13 @@ namespace Gremlin.Net.CosmosDb
             if (elementType != propInfo.ReflectedType && !elementType.IsSubclassOf(propInfo.ReflectedType))
                 throw new ArgumentException($"Expression '{lambda}' refers to a property that is not from type {elementType}.");
 
+            var jsonProperty = propInfo.GetCustomAttributes(typeof(Newtonsoft.Json.JsonPropertyAttribute), false).OfType<Newtonsoft.Json.JsonPropertyAttribute>().FirstOrDefault();
+            if (jsonProperty != null)
+            {
+              if (jsonProperty.PropertyName != null && jsonProperty.PropertyName != "")
+                return jsonProperty.PropertyName;
+            }
+
             return propInfo.Name;
         }
     }

--- a/src/Gremlin.Net.CosmosDb/ISchemaBoundTraversal.Schema.Extensions.cs
+++ b/src/Gremlin.Net.CosmosDb/ISchemaBoundTraversal.Schema.Extensions.cs
@@ -435,7 +435,7 @@ namespace Gremlin.Net.CosmosDb
             var jsonProperty = propInfo.GetCustomAttributes(typeof(Newtonsoft.Json.JsonPropertyAttribute), false).OfType<Newtonsoft.Json.JsonPropertyAttribute>().FirstOrDefault();
             if (jsonProperty != null)
             {
-              if (jsonProperty.PropertyName != null && jsonProperty.PropertyName != "")
+              if (!String.IsNullOrWhiteSpace(jsonProperty.PropertyName))
                 return jsonProperty.PropertyName;
             }
 

--- a/src/Gremlin.Net.CosmosDb/ISchemaBoundTraversal.Schema.Extensions.cs
+++ b/src/Gremlin.Net.CosmosDb/ISchemaBoundTraversal.Schema.Extensions.cs
@@ -432,8 +432,7 @@ namespace Gremlin.Net.CosmosDb
             if (elementType != propInfo.ReflectedType && !elementType.IsSubclassOf(propInfo.ReflectedType))
                 throw new ArgumentException($"Expression '{lambda}' refers to a property that is not from type {elementType}.");
 
-            var jsonProperty = propInfo.GetCustomAttributes(typeof(Newtonsoft.Json.JsonPropertyAttribute), false).OfType<Newtonsoft.Json.JsonPropertyAttribute>().FirstOrDefault();
-            if (jsonProperty != null)
+            if (propInfo.GetCustomAttribute<Newtonsoft.Json.JsonPropertyAttribute>() is var jsonProperty)
             {
               if (!String.IsNullOrWhiteSpace(jsonProperty.PropertyName))
                 return jsonProperty.PropertyName;


### PR DESCRIPTION
This allows a model to annotate each property field with a Newtonsoft.Json.JsonProperty,
and this field is taken into account when constructing `Property` statements with type-safety.
```csharp
public class MyModel : IVertex
{
    [JsonProperty(PropertyName = "myProperty")]
    public string MyProperty { get; set; }
}
```

This is already taken care of by Gremlin.Net driver (i presume..) when `AddV<MyModel>(model)`,
which leads to inconsistencies when attempting to update a field using the property with `Property( p => p.MyProperty, "newValue")`, since the original value was persisted on `myProperty`, and the update sat `MyProperty`.