### PR TITLE
Changed GraphClient unused ctor from internal to public.

### DIFF
--- a/src/Gremlin.Net.CosmosDb/GraphClient.cs
+++ b/src/Gremlin.Net.CosmosDb/GraphClient.cs
@@ -37,7 +37,7 @@ namespace Gremlin.Net.CosmosDb
         /// </summary>
         /// <param name="gremlinClient">The gremlin client.</param>
         /// <exception cref="ArgumentNullException">gremlinClient</exception>
-        internal GraphClient(IGremlinClient gremlinClient)
+        public GraphClient(IGremlinClient gremlinClient)
         {
             _gremlinClient = gremlinClient ?? throw new ArgumentNullException(nameof(gremlinClient));
         }


### PR DESCRIPTION
Our team faced the problem when provided public constructor for this class does not allow enough customization.

To be more precise, we need to customize `RemoteCertificateValidationCallback` via `webSocketConfiguration` in [GremlinClient](https://github.com/apache/tinkerpop/blob/master/gremlin-dotnet/src/Gremlin.Net/Driver/GremlinClient.cs) to avoid SSL headache in component tests.

So this change will allow to extend configuration possibilities for developers.
And I believe it can't break anything since this constructor is internal and unused.

Please let me know if you have any concerns on encapsulation here.