### PR TITLE
Issue49 Query Results Post Processing

### DIFF
--- a/src/Gremlin.Net.CosmosDb/GraphClient.cs
+++ b/src/Gremlin.Net.CosmosDb/GraphClient.cs
@@ -43,6 +43,7 @@ namespace Gremlin.Net.CosmosDb
         /// <exception cref="ArgumentNullException">gremlinClient</exception>
         internal GraphClient(IGremlinClient gremlinClient)
         {
+            _graphSONReader = new GraphSONJTokenReader();
             _gremlinClient = gremlinClient ?? throw new ArgumentNullException(nameof(gremlinClient));
         }
 

--- a/src/Gremlin.Net.CosmosDb/GraphTraversalSource.cs
+++ b/src/Gremlin.Net.CosmosDb/GraphTraversalSource.cs
@@ -1,6 +1,5 @@
 ﻿using Gremlin.Net.CosmosDb.Structure;
 using Gremlin.Net.Process.Traversal;
-using Gremlin.Net.Structure;
 
 namespace Gremlin.Net.CosmosDb
 {
@@ -17,7 +16,7 @@ namespace Gremlin.Net.CosmosDb
         /// </summary>
         public GraphTraversalSource()
         {
-            _graphTraversalSource = new Graph().Traversal();
+            _graphTraversalSource = AnonymousTraversalSource.Traversal();
             _graphTraversalSource.Bytecode.AddSource("g");
         }
 


### PR DESCRIPTION
This handles the breaking changes referenced in evo-terren#49 by doing the processing that used to be done in Gremlin.Net after the fact.  It's not pretty, but it allows us to keep more up-to-date with the Gremlin.Net library.