### PR TITLE
Updated the Gremlin.Net package version to 3.4.2

### DIFF
--- a/src/Gremlin.Net.CosmosDb/GraphTraversalSource.cs
+++ b/src/Gremlin.Net.CosmosDb/GraphTraversalSource.cs
@@ -1,6 +1,5 @@
 ﻿using Gremlin.Net.CosmosDb.Structure;
 using Gremlin.Net.Process.Traversal;
-using Gremlin.Net.Structure;
 
 namespace Gremlin.Net.CosmosDb
 {
@@ -17,7 +16,7 @@ namespace Gremlin.Net.CosmosDb
         /// </summary>
         public GraphTraversalSource()
         {
-            _graphTraversalSource = new Graph().Traversal();
+            _graphTraversalSource = AnonymousTraversalSource.Traversal();
             _graphTraversalSource.Bytecode.AddSource("g");
         }
 

--- a/src/Gremlin.Net.CosmosDb/Gremlin.Net.CosmosDb.csproj
+++ b/src/Gremlin.Net.CosmosDb/Gremlin.Net.CosmosDb.csproj
@@ -7,8 +7,8 @@
     <PackageTags>gremlin cosmos cosmosdb gremlin.net</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Helper library to use Gremlin.Net with a Cosmos DB graph instance</Description>
-    <Copyright>© 2001-2018 evo - All rights reserved, all wrongs reversed</Copyright>
-    <Version>0.3.4.0004-rc1</Version>
+    <Copyright>© 2001-2019 evo - All rights reserved, all wrongs reversed</Copyright>
+    <Version>0.3.4.5-rc1</Version>
     <PackageProjectUrl>https://github.com/evo-terren/Gremlin.Net.CosmosDb</PackageProjectUrl>
     <RepositoryUrl>https://github.com/evo-terren/Gremlin.Net.CosmosDb</RepositoryUrl>
   </PropertyGroup>
@@ -34,7 +34,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Gremlin.Net" Version="3.4.0" />
+    <PackageReference Include="Gremlin.Net" Version="3.4.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Gremlin.Net.CosmosDb/Serialization/AutoConnector.cs
+++ b/src/Gremlin.Net.CosmosDb/Serialization/AutoConnector.cs
@@ -116,7 +116,7 @@ namespace Gremlin.Net.CosmosDb.Serialization
                 {
                     // If we are here it means that the property is non-scalar and not an array. As such, assume it's a
                     // List (otherwise it's non-trivial)
-                    if (prop.GetValue(edge) is IList oldList)
+                    if (prop.GetValue(edge) is IList oldList && !oldList.IsFixedSize)
                     {
                         // If it already exists, add the vertex
                         oldList.Add(vertex);


### PR DESCRIPTION
1) Updated the Gremlin.Net package version to 3.4.2
2) Fixed a failed unit test
3) Remove the obsolete method to create traversal; use AnonymousTraversalSource.Traversal() as recommended.