### PR TITLE
Making constructor of GraphResult public to support mocking for Unit Tests

### DIFF
--- a/src/Gremlin.Net.CosmosDb/Gremlin.Net.CosmosDb.csproj
+++ b/src/Gremlin.Net.CosmosDb/Gremlin.Net.CosmosDb.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Helper library to use Gremlin.Net with a Cosmos DB graph instance</Description>
     <Copyright>© 2001-2019 evo - All rights reserved, all wrongs reversed</Copyright>
-    <Version>0.3.4.5-rc1</Version>
+    <Version>0.3.4.5-rc3</Version>
     <PackageProjectUrl>https://github.com/evo-terren/Gremlin.Net.CosmosDb</PackageProjectUrl>
     <RepositoryUrl>https://github.com/evo-terren/Gremlin.Net.CosmosDb</RepositoryUrl>
   </PropertyGroup>

--- a/src/Gremlin.Net.CosmosDb/Structure/GraphResult.cs
+++ b/src/Gremlin.Net.CosmosDb/Structure/GraphResult.cs
@@ -53,12 +53,12 @@ namespace Gremlin.Net.CosmosDb.Structure
         /// </summary>
         public double TotalRequestCharge => (double)ResultSet.StatusAttributes["x-ms-total-request-charge"];
 
-        internal GraphResult(ResultSet<JToken> resultSet)
+        public GraphResult(ResultSet<JToken> resultSet)
         {
             ResultSet = resultSet ?? throw new System.ArgumentNullException(nameof(resultSet));
         }
 
-        internal GraphResult<T> ApplyType<T>(JsonSerializer serializer)
+        public GraphResult<T> ApplyType<T>(JsonSerializer serializer)
         {
             return new GraphResult<T>(ResultSet, serializer);
         }


### PR DESCRIPTION
Fix for #65 ,

As pointed out [here](https://github.com/evo-terren/Gremlin.Net.CosmosDb/issues/65#issuecomment-524161390), 

Even using interface for `GraphResult` would not solve the issue.
Hence, making the constructor from `internal` to `public`